### PR TITLE
feat: add support for basic auth via url

### DIFF
--- a/cmd/example1/main.go
+++ b/cmd/example1/main.go
@@ -54,6 +54,10 @@ func main() {
 		fmt.Println("--> Run with proxy on localhost")
 		runTest(func(req *http.Request) (*url.URL, error) { return url.Parse("http://localhost:3128") })
 
+		// this case uses basic authentication
+		fmt.Println("--> Run with basic proxy authentication from url ")
+		runTest(func(req *http.Request) (*url.URL, error) { return url.Parse("http://user:password@localhost:3128") })
+
 		env.StopProxyEnvironment()
 	}
 }

--- a/pkg/httpauth/httpauth.go
+++ b/pkg/httpauth/httpauth.go
@@ -13,6 +13,7 @@ const (
 	NoAuth           AuthenticationMechanism = "noauth"
 	Negotiate        AuthenticationMechanism = "negotiate"
 	AnyAuth          AuthenticationMechanism = "anyauth"
+	BasicAuth        AuthenticationMechanism = "basic"
 	UnknownMechanism AuthenticationMechanism = "unknownmechanism"
 )
 

--- a/pkg/httpauth/httpauth_generated_mock.go
+++ b/pkg/httpauth/httpauth_generated_mock.go
@@ -88,6 +88,20 @@ func (mr *MockAuthenticationHandlerInterfaceMockRecorder) IsStopped() *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStopped", reflect.TypeOf((*MockAuthenticationHandlerInterface)(nil).IsStopped))
 }
 
+// SetBasicAuthentication mocks base method.
+func (m *MockAuthenticationHandlerInterface) SetBasicAuthentication(userInfo *url.Userinfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetBasicAuthentication", userInfo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetBasicAuthentication indicates an expected call of SetBasicAuthentication.
+func (mr *MockAuthenticationHandlerInterfaceMockRecorder) SetBasicAuthentication(userInfo interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBasicAuthentication", reflect.TypeOf((*MockAuthenticationHandlerInterface)(nil).SetBasicAuthentication), userInfo)
+}
+
 // SetLogger mocks base method.
 func (m *MockAuthenticationHandlerInterface) SetLogger(logger *log.Logger) {
 	m.ctrl.T.Helper()

--- a/test/helper/mock_http_server.go
+++ b/test/helper/mock_http_server.go
@@ -9,6 +9,7 @@ import (
 type MockServer struct {
 	Port          int
 	ResponseList  []*http.Response
+	RequestList   []*http.Request
 	responseIndex int
 	listener      net.Listener
 }
@@ -33,6 +34,8 @@ func (m *MockServer) Listen() {
 
 func (m *MockServer) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	var response *http.Response
+
+	m.RequestList = append(m.RequestList, request)
 
 	if m.responseIndex < len(m.ResponseList) {
 		response = m.ResponseList[m.responseIndex]


### PR DESCRIPTION
### What this does
Implements the possibility to use basic authentication if the proxy URL contains a username and password.
