### PR TITLE
chore: remove log message ‘No Proxy defined …’

### DIFF
--- a/pkg/httpauth/proxy_authenticator.go
+++ b/pkg/httpauth/proxy_authenticator.go
@@ -65,7 +65,6 @@ func (p *ProxyAuthenticator) DialContext(ctx context.Context, network, addr stri
 			fmt.Println("Failed to connect to Proxy! ", proxyUrl)
 		}
 	} else {
-		p.debugLogger.Println("No Proxy defined for ", addr, "!")
 		connection, err = net.Dial(network, addr)
 	}
 


### PR DESCRIPTION
### What this does
The log message 'No Proxy defined for  yxz !' confused multiple users, so we remove it as it has not too much value anyways.