### PR TITLE
fix: don’t print errors on stdout

### DIFF
--- a/pkg/httpauth/authenticationhandler.go
+++ b/pkg/httpauth/authenticationhandler.go
@@ -87,8 +87,8 @@ func (a *AuthenticationHandler) GetAuthorizationValue(url *url.URL, responseToke
 		authorizeValue = mechanism + " " + token
 
 		if len(token) > 0 {
-			mechanisms, _ := GetMechanismsFromHttpFieldValue(authorizeValue)
-			a.logger.Printf("Authorization to %s using: %s", url, mechanisms)
+			mechanisms, errMechanism := GetMechanismsFromHttpFieldValue(authorizeValue)
+			a.logger.Printf("Authorization to %s using: %s (err=%v)", url, mechanisms, errMechanism)
 		}
 	} else if a.activeMechanism == BasicAuth { // supporting mechanism: Basic
 		password, _ := a.userInfo.Password()

--- a/pkg/httpauth/proxy_authenticator.go
+++ b/pkg/httpauth/proxy_authenticator.go
@@ -62,7 +62,7 @@ func (p *ProxyAuthenticator) DialContext(ctx context.Context, network, addr stri
 		connection, err = p.connectToProxy(ctx, proxyUrl, addr, createConnectionFunc)
 
 		if err != nil {
-			fmt.Println("Failed to connect to Proxy! ", proxyUrl)
+			p.debugLogger.Println("Failed to connect to Proxy! ", proxyUrl)
 		}
 	} else {
 		connection, err = net.Dial(network, addr)

--- a/pkg/httpauth/spnego.go
+++ b/pkg/httpauth/spnego.go
@@ -51,10 +51,6 @@ func GetMechanismsFromHttpFieldValue(token string) ([]string, error) {
 			}
 
 		}
-
-		if err != nil {
-			fmt.Println(err)
-		}
 	}
 
 	return result, err


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Some code paths were writing errors to stdout, which can cause issues when the library is integrated in Applications that make use of stdout. This is now replaced by using the logger.

### Notes for the reviewer

### More information

### Screenshots

