### PR TITLE
chore(ci): upgrade from deprecated image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   linux:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: default
 
 # Define the jobs we want to run for this project
 jobs:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

We were using a deprecated image, which resulted in jobs failing. Example:
https://app.circleci.com/pipelines/github/snyk/go-httpauth/59/workflows/ead375c0-ad6a-4686-bb88-31a1d09e9567/jobs/158